### PR TITLE
#28 refactor - 코드 구조 수정

### DIFF
--- a/app/src/main/java/com/example/woowagithubrepositoryapp/repository/GithubRepository.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/repository/GithubRepository.kt
@@ -19,13 +19,13 @@ class GithubRepository {
             body.apply {
                 starredCnt = starredReposCnt
             }
-        }else null
+        } else null
     }
 
-    suspend fun getNotifications(page: Int) : MutableList<Notification> {
-        return try{
+    suspend fun getNotifications(page: Int): MutableList<Notification> {
+        return try {
             val response = service.getNotifications(page = page)
-            if(response.isSuccessful){
+            if (response.isSuccessful) {
                 val notifications = response.body()?.toMutableList() ?: mutableListOf()
                 notifications.forEach {
                     val info = getNotificationInfo(it.subject.url)
@@ -34,29 +34,29 @@ class GithubRepository {
                 }
                 notifications
             } else mutableListOf()
-        } catch (e : Exception) {
-            Log.d("getNotiError",e.cause.toString())
+        } catch (e: Exception) {
+            Log.d("getNotiError", e.cause.toString())
             mutableListOf()
         }
     }
 
     suspend fun patchNotificationThread(
-        threadId : String
-    ) : Boolean {
+        threadId: String
+    ): Boolean {
         return try {
             val response = service.patchNotificationThread(threadId)
             response.isSuccessful
-        } catch (e : Exception){
-            Log.d("patchNotiThreadError",e.cause.toString())
+        } catch (e: Exception) {
+            Log.d("patchNotiThreadError", e.cause.toString())
             false
         }
     }
 
-    private suspend fun getNotificationInfo(fullUrl : String) : NotificationInfo? {
+    private suspend fun getNotificationInfo(fullUrl: String): NotificationInfo? {
         return try {
             service.getNotificationInfo(fullUrl).body()
-        } catch (e : Exception){
-            Log.d("getNotiInfoError",e.cause.toString())
+        } catch (e: Exception) {
+            Log.d("getNotiInfoError", e.cause.toString())
             null
         }
     }
@@ -64,30 +64,28 @@ class GithubRepository {
     suspend fun getUserIssues(
         state: String,
         page: Int
-    ) : List<Issue>{
+    ): List<Issue> {
         val response = service.getIssues(
             state = state,
             page = page
         )
         val body = response.body()
-        if(response.isSuccessful && body != null){
+        if (response.isSuccessful && body != null) {
             return body
         }
         return listOf()
     }
 
-
-
     suspend fun searchRepos(
         searchText: String,
         page: Int
-    ) : RepoResponse?{
+    ): RepoResponse? {
         val response = service.searchRepositories(
             searchText = searchText,
             page = page
         )
         val body = response.body()
-        return if (response.isSuccessful && body != null){
+        return if (response.isSuccessful && body != null) {
             body
         } else null
     }

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/repository/GithubRepository.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/repository/GithubRepository.kt
@@ -1,11 +1,8 @@
 package com.example.woowagithubrepositoryapp.repository
 
 import android.util.Log
-import com.example.woowagithubrepositoryapp.model.Issue
-import com.example.woowagithubrepositoryapp.model.Notification
-import com.example.woowagithubrepositoryapp.model.User
+import com.example.woowagithubrepositoryapp.model.*
 import com.example.woowagithubrepositoryapp.network.GithubClient
-import com.example.woowagithubrepositoryapp.model.NotificationInfo
 import com.example.woowagithubrepositoryapp.network.GithubService
 import retrofit2.Call
 import retrofit2.Callback
@@ -84,10 +81,16 @@ class GithubRepository {
     suspend fun searchRepos(
         searchText: String,
         page: Int
-    ) = service.searchRepositories(
-        searchText = searchText,
-        page = page
-    )
+    ) : RepoResponse?{
+        val response = service.searchRepositories(
+            searchText = searchText,
+            page = page
+        )
+        val body = response.body()
+        return if (response.isSuccessful && body != null){
+            body
+        } else null
+    }
 
     private suspend fun getStarredRepos(): Int {
         val response = service.getStarredRepos()

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/repository/GithubRepository.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/repository/GithubRepository.kt
@@ -1,6 +1,7 @@
 package com.example.woowagithubrepositoryapp.repository
 
 import android.util.Log
+import com.example.woowagithubrepositoryapp.model.Issue
 import com.example.woowagithubrepositoryapp.model.Notification
 import com.example.woowagithubrepositoryapp.model.User
 import com.example.woowagithubrepositoryapp.network.GithubClient
@@ -66,10 +67,19 @@ class GithubRepository {
     suspend fun getUserIssues(
         state: String,
         page: Int
-    ) = service.getIssues(
-        state = state,
-        page = page
-    )
+    ) : List<Issue>{
+        val response = service.getIssues(
+            state = state,
+            page = page
+        )
+        val body = response.body()
+        if(response.isSuccessful && body != null){
+            return body
+        }
+        return listOf()
+    }
+
+
 
     suspend fun searchRepos(
         searchText: String,

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/ui/issue/IssueViewModel.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/ui/issue/IssueViewModel.kt
@@ -15,12 +15,12 @@ class IssueViewModel(private val repository: GithubRepository) : ViewModel() {
     val selectState = MutableLiveData("open")
     val issueList = mutableListOf<Issue>()
 
-    fun getIssues(complete: (List<Issue>) -> Unit){
+    fun getIssues(complete: (List<Issue>) -> Unit) {
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                val issues = repository.getUserIssues(selectState.value!!,pageNumber.value!!)
-                withContext(Dispatchers.Main){
-                    if(pageNumber.value == 1)
+                val issues = repository.getUserIssues(selectState.value!!, pageNumber.value!!)
+                withContext(Dispatchers.Main) {
+                    if (pageNumber.value == 1)
                         issueList.clear()
                     issueList.addAll(issues)
                     complete(issueList)

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/ui/issue/IssueViewModel.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/ui/issue/IssueViewModel.kt
@@ -18,17 +18,12 @@ class IssueViewModel(private val repository: GithubRepository) : ViewModel() {
     fun getIssues(complete: (List<Issue>) -> Unit){
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                val response = repository.getUserIssues(
-                    selectState.value!!, pageNumber.value!!
-                )
-                val body = response.body()
-                if (response.isSuccessful && body != null) {
-                    withContext(Dispatchers.Main){
-                        if(pageNumber.value == 1)
-                            issueList.clear()
-                        issueList.addAll(body)
-                        complete(issueList)
-                    }
+                val issues = repository.getUserIssues(selectState.value!!,pageNumber.value!!)
+                withContext(Dispatchers.Main){
+                    if(pageNumber.value == 1)
+                        issueList.clear()
+                    issueList.addAll(issues)
+                    complete(issueList)
                 }
             } catch (e: Exception) {
                 Log.e("IssueViewModel", "getIssues error")

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/ui/search/SearchViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.viewModelScope
 import com.example.woowagithubrepositoryapp.model.Repo
 import com.example.woowagithubrepositoryapp.repository.GithubRepository
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -25,7 +24,7 @@ class SearchViewModel(private val repository: GithubRepository) : ViewModel() {
                 val repoResponse = repository.searchRepos(q, pageNumber)
                 withContext(Dispatchers.Main) {
                     repoResponse?.let {
-                        if (it.totalCount > 0){
+                        if (it.totalCount > 0) {
                             repoList.addAll(it.items)
                             complete(repoList)
                             recyclerViewOn.value = true

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/ui/search/SearchViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.woowagithubrepositoryapp.model.Repo
 import com.example.woowagithubrepositoryapp.repository.GithubRepository
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -21,14 +22,11 @@ class SearchViewModel(private val repository: GithubRepository) : ViewModel() {
         viewModelScope.launch(Dispatchers.IO) {
             val q = searchText.value.toString()
             try {
-                val response = repository.searchRepos(q, pageNumber)
-                val body = response.body()
-                if (response.isSuccessful && body != null) {
-                    withContext(Dispatchers.Main) {
-                        if (body.totalCount == 0) {
-                            recyclerViewOn.value = false
-                        } else {
-                            repoList.addAll(body.items)
+                val repoResponse = repository.searchRepos(q, pageNumber)
+                withContext(Dispatchers.Main) {
+                    repoResponse?.let {
+                        if (it.totalCount > 0){
+                            repoList.addAll(it.items)
                             complete(repoList)
                             recyclerViewOn.value = true
                         }


### PR DESCRIPTION
## 수정 사항
통신 response의 성공 여부 확인 및 데이터 변환 과정을 repository 내부로 이동하였습니다.


## 추가 의견
통신 실패의 경우 사용자에게 토스트를 띄운다거나 하는 부분을 고려해 `try-catch`부분을 ViewModel에 그대로 놔두었습니다. 이에 대한 협의가 필요할 듯 싶습니다.