### PR TITLE
#62 FEAT 탭 Reselect 시 refresh 하도록 수정

### DIFF
--- a/app/src/main/java/com/example/woowagithubrepositoryapp/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/ui/MainActivity.kt
@@ -55,32 +55,33 @@ class MainActivity : AppCompatActivity(), TabLayout.OnTabSelectedListener {
     private fun setStateObserve() {
         viewModel.tabSelectState.observe(this) {
             when (setOf(it.text,it.isReselected)) {
-                setOf("Issue",false) -> {
-                    if (issueFragment == null)
-                        issueFragment = IssueFragment()
-                    changeFragmentToIssueFragment()
+                setOf("Notifications",true)  -> {
+                    viewModel.refreshNotifications()
                 }
                 setOf("Notifications",false)  -> {
                     if (notificationFragment == null)
                         notificationFragment = NotificationFragment()
                     changeFragmentToNotificationFragment()
                 }
-                setOf("Issue",true) -> {
-                    viewModel.refreshIssues()
+                else -> {
+                    if (issueFragment == null)
+                        issueFragment = IssueFragment()
+                    if(it.isReselected){
+                        //TODO 필요하다면 viewModel.refreshIssue 구현
+                    }
+                    changeFragmentToIssueFragment()
                 }
-                setOf("Notifications",true)  -> {
-                    viewModel.refreshNotifications()
-                }
+
             }
         }
     }
 
     private fun initTabLayout(tabLayout: TabLayout) {
+        tabLayout.addOnTabSelectedListener(this)
         resources.getStringArray(R.array.main_tab).forEach { tabName ->
             tabLayout.addTab(tabLayout.newTab().setText(tabName))
         }
 
-        tabLayout.addOnTabSelectedListener(this)
         when (viewModel.tabSelectState.value?.text) {
             "Issue" -> tabLayout.selectTab(tabLayout.getTabAt(0))
             else -> tabLayout.selectTab(tabLayout.getTabAt(1))

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/ui/MainActivity.kt
@@ -54,16 +54,22 @@ class MainActivity : AppCompatActivity(), TabLayout.OnTabSelectedListener {
 
     private fun setStateObserve() {
         viewModel.tabSelectState.observe(this) {
-            when (it) {
-                "Issue" -> {
+            when (setOf(it.text,it.isReselected)) {
+                setOf("Issue",false) -> {
                     if (issueFragment == null)
                         issueFragment = IssueFragment()
                     changeFragmentToIssueFragment()
                 }
-                else -> {
+                setOf("Notifications",false)  -> {
                     if (notificationFragment == null)
                         notificationFragment = NotificationFragment()
                     changeFragmentToNotificationFragment()
+                }
+                setOf("Issue",true) -> {
+                    viewModel.refreshIssues()
+                }
+                setOf("Notifications",true)  -> {
+                    viewModel.refreshNotifications()
                 }
             }
         }
@@ -75,7 +81,7 @@ class MainActivity : AppCompatActivity(), TabLayout.OnTabSelectedListener {
         }
 
         tabLayout.addOnTabSelectedListener(this)
-        when (viewModel.tabSelectState.value) {
+        when (viewModel.tabSelectState.value?.text) {
             "Issue" -> tabLayout.selectTab(tabLayout.getTabAt(0))
             else -> tabLayout.selectTab(tabLayout.getTabAt(1))
         }
@@ -112,7 +118,7 @@ class MainActivity : AppCompatActivity(), TabLayout.OnTabSelectedListener {
 
     override fun onTabSelected(tab: TabLayout.Tab?) {
         tab?.let {
-            viewModel.tabSelectState.value = it.text.toString()
+            viewModel.tabSelectState.value = TabSelectState(it.text.toString(),false)
         }
     }
 
@@ -122,16 +128,7 @@ class MainActivity : AppCompatActivity(), TabLayout.OnTabSelectedListener {
 
     override fun onTabReselected(tab: TabLayout.Tab?) {
         tab?.let {
-            when (it.text) {
-                "Issue" -> {
-                    issueFragment = IssueFragment()
-                    changeFragmentToIssueFragment()
-                }
-                else -> {
-                    notificationFragment = NotificationFragment()
-                    changeFragmentToNotificationFragment()
-                }
-            }
+            viewModel.tabSelectState.value = TabSelectState(it.text.toString(),true)
         }
     }
 

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/ui/MainViewModel.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/ui/MainViewModel.kt
@@ -20,11 +20,11 @@ class MainViewModel(private val repository: GithubRepository) : ViewModel() {
     val issueSelectState = MutableLiveData("open")
     val issueList = mutableListOf<Issue>()
 
-    val tabSelectState = MutableLiveData("Issue")
+    val tabSelectState = MutableLiveData(TabSelectState("Issue",false))
 
     private val _notifications = MutableLiveData<MutableList<Notification>>()
     val notifications: LiveData<MutableList<Notification>> = _notifications
-    private var notificationPage = 1
+    var notificationPage = 1
     var isNotificationDataLoading: Constants.DataLoading = Constants.DataLoading.BEFORE
 
     init {
@@ -120,9 +120,21 @@ class MainViewModel(private val repository: GithubRepository) : ViewModel() {
         }
     }
 
+    fun refreshNotifications(){
+        _notifications.postValue(mutableListOf())
+        notificationPage = 1
+        getNotifications()
+    }
+
+    fun refreshIssues(){
+        issueList.clear()
+        issuePage.postValue(1)
+        issueSelectState.postValue("open")
+    }
+
     private fun removeNotificationAtPosition(notification: Notification) {
         _notifications.value?.remove(notification)
         _notifications.value = _notifications.value
     }
 }
-
+class TabSelectState(val text: String,val isReselected : Boolean)


### PR DESCRIPTION
- [ ] 기존의 tab text만 저장하던 state 를 text와 Reselected Boolean 객체로 수정
- [ ] 이슈 탭 경우, 처음 액티비티에 진입하고 탭이 나타날 때 이슈탭으로 select 되어 있는 상태이므로 그에 맞게 수정