### PR TITLE
#73 알림 async, await 이용해서 동시에 API 요청 신호 보내기

### DIFF
--- a/app/src/main/java/com/example/woowagithubrepositoryapp/model/NotificationInfo.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/model/NotificationInfo.kt
@@ -5,4 +5,5 @@ import com.google.gson.annotations.SerializedName
 data class NotificationInfo(
     @SerializedName("number") val number : Int,
     @SerializedName("comments") val comments : Int,
+    var notificationId : String = ""
 )


### PR DESCRIPTION
async, await를 이용해서 한 번에 10개(기존 목록 사이즈)의 요청을 보내고 응답을 받는 식으로 수정하였습니다.
로그로 걸린 시간을 비교해보니 3~4초 정도 시간이 개선되었습니다.
