### PR TITLE
#51 rotate - issue 정보 재호출 방지, 기기회전 시 issue 목록 유지

### DIFF
--- a/app/src/main/java/com/example/woowagithubrepositoryapp/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/ui/MainActivity.kt
@@ -3,12 +3,10 @@ package com.example.woowagithubrepositoryapp.ui
 import android.content.Intent
 import android.graphics.drawable.Drawable
 import android.os.Bundle
-import android.util.Log
 import android.view.Menu
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.CircleCrop
@@ -48,8 +46,9 @@ class MainActivity : AppCompatActivity(), TabLayout.OnTabSelectedListener {
         initTabLayout(binding.mainTabLayout)
         initToolbar(binding.mainToolbar)
         setStateObserve()
-
-        viewModel.getUserData { invalidateOptionsMenu() }
+        if(App.user == null){
+            viewModel.getUserData { invalidateOptionsMenu() }
+        }
     }
 
     private fun setStateObserve() {
@@ -62,8 +61,7 @@ class MainActivity : AppCompatActivity(), TabLayout.OnTabSelectedListener {
                     changeFragmentByTag(it.text)
                 }
                 setOf(Constants.Tab.ISSUE.text,true)  -> {
-                    //viewModel.refreshIssues()
-                    changeFragmentByTag(it.text)
+                    viewModel.refreshIssues()
                 }
                 setOf(Constants.Tab.ISSUE.text,false)  -> {
                     changeFragmentByTag(it.text)

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/ui/MainViewModel.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/ui/MainViewModel.kt
@@ -18,6 +18,8 @@ class MainViewModel(private val repository: GithubRepository) : ViewModel() {
     val issuePage = MutableLiveData(1)
     val issueSelectState = MutableLiveData("open")
     val issueList = mutableListOf<Issue>()
+    val issueRefreshState = MutableLiveData(true)
+    var issueLoadType = Constants.IssueLoadType.CREATE
 
     val tabSelectState = MutableLiveData(TabSelectState("Issue", false))
 
@@ -112,15 +114,16 @@ class MainViewModel(private val repository: GithubRepository) : ViewModel() {
     }
 
     fun refreshNotifications() {
-        _notifications.postValue(mutableListOf())
+        _notifications.value = mutableListOf()
         notificationPage = 1
         getNotifications()
     }
 
     fun refreshIssues() {
         issueList.clear()
-        issuePage.postValue(1)
-        issueSelectState.postValue("open")
+        issuePage.value = 1
+        issueLoadType = Constants.IssueLoadType.CREATE
+        issueRefreshState.value = issueRefreshState.value == false
     }
 
     private fun removeNotificationAtPosition(notification: Notification) {

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/utils/Constants.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/utils/Constants.kt
@@ -13,4 +13,8 @@ object Constants {
     enum class Tab(val text : String) {
         ISSUE("Issue"), NOTI("Notifications")
     }
+
+    enum class IssueLoadType{
+        CREATE, LOAD, PAGING
+    }
 }


### PR DESCRIPTION
issue를 불러오는 상황을 분리하여 issue  정보를 다시 불러오는 것을 방지하였습니다. 그리고 tab reselect 시 recyclerview만 갱신 할 수 있도록 하였습니다.