### PR TITLE
#104 bug - 읽음 처리할 목록 추가 후 fragment onStop시 읽음 처리와 refresh하도록 구현

### DIFF
--- a/app/src/main/java/com/example/woowagithubrepositoryapp/data/datasource/GithubDataSource.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/data/datasource/GithubDataSource.kt
@@ -1,0 +1,26 @@
+package com.example.woowagithubrepositoryapp.data.datasource
+
+import com.example.woowagithubrepositoryapp.model.Issue
+import com.example.woowagithubrepositoryapp.model.Notification
+import com.example.woowagithubrepositoryapp.model.RepoResponse
+import com.example.woowagithubrepositoryapp.model.User
+
+interface GithubDataSource {
+    suspend fun getUserData(): Result<User>
+
+    suspend fun getNotifications(page: Int): Result<MutableList<Notification>>
+
+    suspend fun patchNotificationThread(
+        threadId: String
+    ): Result<Boolean>
+
+    suspend fun getUserIssues(
+        state: String,
+        page: Int
+    ): Result<List<Issue>>
+
+    suspend fun searchRepos(
+        searchText: String,
+        page: Int
+    ): Result<RepoResponse>
+}

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/data/datasource/GithubDataSource.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/data/datasource/GithubDataSource.kt
@@ -1,26 +1,30 @@
 package com.example.woowagithubrepositoryapp.data.datasource
 
-import com.example.woowagithubrepositoryapp.model.Issue
-import com.example.woowagithubrepositoryapp.model.Notification
-import com.example.woowagithubrepositoryapp.model.RepoResponse
-import com.example.woowagithubrepositoryapp.model.User
+import com.example.woowagithubrepositoryapp.model.*
 
 interface GithubDataSource {
     suspend fun getUserData(): Result<User>
 
     suspend fun getNotifications(page: Int): Result<MutableList<Notification>>
 
-    suspend fun patchNotificationThread(
-        threadId: String
-    ): Result<Boolean>
+    suspend fun patchNotificationThread(threadId: String): Result<Boolean>
+
+    suspend fun getStarredRepos(): Result<Int>
 
     suspend fun getUserIssues(
         state: String,
         page: Int
     ): Result<List<Issue>>
 
-    suspend fun searchRepos(
+    suspend fun getRepos(
         searchText: String,
         page: Int
     ): Result<RepoResponse>
+
+    suspend fun getNotificationInfo(
+        fullUrl: String,
+        id: String)
+    : Result<NotificationInfo?>
+
+
 }

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/data/datasource/GithubDataSource.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/data/datasource/GithubDataSource.kt
@@ -22,9 +22,8 @@ interface GithubDataSource {
     ): Result<RepoResponse>
 
     suspend fun getNotificationInfo(
-        fullUrl: String,
-        id: String)
-    : Result<NotificationInfo?>
+        fullUrl: String
+    ) : Result<NotificationInfo?>
 
 
 }

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/data/datasource/GithubDataSource.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/data/datasource/GithubDataSource.kt
@@ -7,7 +7,7 @@ interface GithubDataSource {
 
     suspend fun getNotifications(page: Int): Result<MutableList<Notification>>
 
-    suspend fun patchNotificationThread(threadId: String): Result<Boolean>
+    suspend fun patchNotificationThread(threadIds: MutableList<String>): Result<Boolean>
 
     suspend fun getStarredRepos(): Result<Int>
 

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/data/datasource/GithubRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/data/datasource/GithubRemoteDataSourceImpl.kt
@@ -1,40 +1,113 @@
 package com.example.woowagithubrepositoryapp.data.datasource
 
+import android.util.Log
 import com.example.woowagithubrepositoryapp.data.network.GithubClient
 import com.example.woowagithubrepositoryapp.data.network.GithubService
 import com.example.woowagithubrepositoryapp.model.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 import java.io.IOException
 
 class GithubRemoteDataSourceImpl : GithubDataSource {
     private val service = GithubClient().generate(GithubService::class.java)
 
-    override suspend fun getUserData(): Result<User> {
-        TODO("Not yet implemented")
+    override suspend fun getUserData()
+    : Result<User> = withContext(Dispatchers.IO) {
+        try {
+            val response = service.getUserData()
+            val body = response.body()
+            if (response.isSuccessful && body != null) {
+                Result.success(body)
+            } else Result.failure(Exception("Get User Data Error"))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
-    override suspend fun getNotifications(page: Int): Result<MutableList<Notification>> {
-        TODO("Not yet implemented")
+    override suspend fun getNotifications(page: Int)
+    : Result<MutableList<Notification>> = withContext(Dispatchers.IO) {
+        try {
+            val response = service.getNotifications(page = page)
+            val body = response.body()
+            return@withContext if (response.isSuccessful && body != null) {
+                Result.success(body.toMutableList())
+            } else Result.failure(Exception("GetNotificationsError"))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
-    override suspend fun patchNotificationThread(threadId: String): Result<Boolean> {
-        TODO("Not yet implemented")
+
+    override suspend fun patchNotificationThread(threadId: String)
+    : Result<Boolean> = withContext(Dispatchers.IO) {
+        try {
+            val response = service.patchNotificationThread(threadId)
+            return@withContext if(response.isSuccessful) {
+                Result.success(true)
+            } else Result.failure(Exception("patchNotiThreadError"))
+        }
+        catch (e: IOException) {
+            Log.d("patchNotiThreadError", e.cause.toString())
+            Result.failure(e)
+        }
     }
 
-    override suspend fun getStarredRepos(): Result<Int>  {
-        TODO("Not yet implemented")
+    override suspend fun getStarredRepos()
+    : Result<Int> = withContext(Dispatchers.IO){
+        try {
+            val response = service.getStarredRepos()
+            val body = response.body()
+            return@withContext if (response.isSuccessful && body != null) {
+                Result.success(body.size)
+            } else Result.failure(Exception("getStarredReposError"))
+        }
+        catch (e : Exception){
+            return@withContext Result.failure(e)
+        }
     }
 
-    override suspend fun getUserIssues(state: String, page: Int): Result<List<Issue>> {
-        TODO("Not yet implemented")
+    override suspend fun getUserIssues(state: String, page: Int)
+    : Result<List<Issue>> = withContext(Dispatchers.IO) {
+        try {
+            val response = service.getIssues(
+                state = state,
+                page = page
+            )
+            val body = response.body()
+            if (response.isSuccessful && body != null)
+                Result.success(body)
+            else
+                Result.failure(Exception("getUserIssuesError"))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
-    override suspend fun getRepos(searchText: String, page: Int): Result<RepoResponse> {
-        TODO("Not yet implemented")
+    override suspend fun getRepos(searchText: String, page: Int)
+    : Result<RepoResponse>  = withContext(Dispatchers.IO) {
+        try {
+            val response = service.searchRepositories(
+                searchText = searchText,
+                page = page
+            )
+            val body = response.body()
+            if (response.isSuccessful && body != null)
+                Result.success(body)
+            else Result.failure(Exception("getReposError"))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
-    override suspend fun getNotificationInfo(fullUrl: String, id: String): Result<NotificationInfo?> {
-        TODO("Not yet implemented")
+    override suspend fun getNotificationInfo(fullUrl: String)
+    : Result<NotificationInfo?> = withContext(Dispatchers.IO) {
+        try {
+            val response = service.getNotificationInfo(fullUrl)
+            val body = response.body()
+            if (response.isSuccessful && body != null)
+                Result.success(body)
+            else Result.failure(Exception("getNotificationInfosError"))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 }

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/data/datasource/GithubRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/data/datasource/GithubRemoteDataSourceImpl.kt
@@ -1,0 +1,40 @@
+package com.example.woowagithubrepositoryapp.data.datasource
+
+import com.example.woowagithubrepositoryapp.data.network.GithubClient
+import com.example.woowagithubrepositoryapp.data.network.GithubService
+import com.example.woowagithubrepositoryapp.model.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.IOException
+
+class GithubRemoteDataSourceImpl : GithubDataSource {
+    private val service = GithubClient().generate(GithubService::class.java)
+
+    override suspend fun getUserData(): Result<User> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getNotifications(page: Int): Result<MutableList<Notification>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun patchNotificationThread(threadId: String): Result<Boolean> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getStarredRepos(): Result<Int>  {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getUserIssues(state: String, page: Int): Result<List<Issue>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getRepos(searchText: String, page: Int): Result<RepoResponse> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getNotificationInfo(fullUrl: String, id: String): Result<NotificationInfo?> {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/data/repository/GithubRepository.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/data/repository/GithubRepository.kt
@@ -11,7 +11,7 @@ interface GithubRepository {
     suspend fun getNotifications(page: Int): Result<MutableList<Notification>>
 
     suspend fun patchNotificationThread(
-        threadId: String
+        threadIds: MutableList<String>
     ): Result<Boolean>
 
     suspend fun getUserIssues(

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/data/repository/GithubRepositoryImpl.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/data/repository/GithubRepositoryImpl.kt
@@ -58,9 +58,9 @@ class GithubRepositoryImpl : GithubRepository {
     }
 
     override suspend fun patchNotificationThread(
-        threadId: String
+        threadIds: MutableList<String>
     ): Result<Boolean> {
-        return dataSource.patchNotificationThread(threadId)
+        return dataSource.patchNotificationThread(threadIds)
     }
 
     override suspend fun getUserIssues(

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/data/repository/GithubRepositoryImpl.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/data/repository/GithubRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package com.example.woowagithubrepositoryapp.data.repository
 
 import android.util.Log
+import com.example.woowagithubrepositoryapp.data.datasource.GithubDataSource
+import com.example.woowagithubrepositoryapp.data.datasource.GithubRemoteDataSourceImpl
 import com.example.woowagithubrepositoryapp.data.network.GithubClient
 import com.example.woowagithubrepositoryapp.data.network.GithubService
 import com.example.woowagithubrepositoryapp.model.*
@@ -9,116 +11,70 @@ import java.io.IOException
 
 class GithubRepositoryImpl : GithubRepository {
     private val service = GithubClient().generate(GithubService::class.java)
+    private val dataSource = GithubRemoteDataSourceImpl()
 
-    override suspend fun getUserData(): Result<User> = withContext(Dispatchers.IO) {
-        try {
-            val response = service.getUserData()
-            val body = response.body()
-            if (response.isSuccessful && body != null) {
-                val starredReposCnt = getStarredRepos()
-                body.apply {
-                    starredCnt = starredReposCnt
-                }
-                Result.success(body)
-            } else Result.failure(Exception("Get User Data Error"))
-        } catch (e: Exception) {
+    override suspend fun getUserData(): Result<User> {
+        return try {
+            val getUserDataResult = dataSource.getUserData()
+            if(getUserDataResult.isSuccess){
+                val userData = getUserDataResult.getOrThrow()
+                val starredRepos = dataSource.getStarredRepos().getOrThrow()
+                Result.success(userData.apply {
+                    this.starredCnt = starredRepos
+                })
+            }
+            else {
+                getUserDataResult
+            }
+        }
+        catch (e : Exception){
             Result.failure(e)
         }
     }
 
-    override suspend fun getNotifications(page: Int): Result<MutableList<Notification>> =
-        withContext(Dispatchers.IO) {
-            supervisorScope {
-                try {
-                    val response = service.getNotifications(page = page)
-                    if (response.isSuccessful) {
-                        val notifications = response.body()?.toMutableList() ?: mutableListOf()
-                        val notificationInfos = notifications.map {
-                            async {
-                                getNotificationInfo(it.subject.url, it.id)
-                            }
-                        }.awaitAll()
-
-                        Result.success(notifications.zip(notificationInfos) { notification, notificationInfo ->
-                            notification.apply {
-                                this.comments = notificationInfo?.comments.toString()
-                                this.issueNum = "#${notificationInfo?.number}"
-                            }
-                        }.toMutableList())
-                    } else Result.failure(Exception("Get Notifications Error : response isn't successful"))
-                } catch (e: Exception) {
-                    Log.d("getNotiError", e.cause.toString())
-                    Result.failure(e)
-                }
-            }
+    override suspend fun getNotifications(page: Int)
+    : Result<MutableList<Notification>> = supervisorScope {
+        return@supervisorScope try {
+            val getNotificationResult = dataSource.getNotifications(page)
+            if (getNotificationResult.isSuccess) {
+                val notifications = getNotificationResult.getOrThrow()
+                val notificationInfo = notifications.map {
+                    async {
+                        dataSource.getNotificationInfo(it.subject.url).getOrThrow()
+                    }
+                }.awaitAll()
+                Result.success(notifications.zip(notificationInfo) { noti, notiInfo ->
+                    noti.apply {
+                        this.comments = notiInfo?.comments.toString()
+                        this.issueNum = "#${notiInfo?.number}"
+                    }
+                }.toMutableList())
+            } else
+                getNotificationResult
         }
+        catch(e: Exception) {
+            Result.failure(e)
+        }
+    }
 
     override suspend fun patchNotificationThread(
         threadId: String
-    ): Result<Boolean> = withContext(Dispatchers.IO) {
-        try {
-            val response = service.patchNotificationThread(threadId)
-            Result.success(response.isSuccessful)
-        } catch (e: Exception) {
-            Log.d("patchNotiThreadError", e.cause.toString())
-            Result.failure(e)
-        }
+    ): Result<Boolean> {
+        return dataSource.patchNotificationThread(threadId)
     }
 
     override suspend fun getUserIssues(
         state: String,
         page: Int
-    ): Result<List<Issue>> = withContext(Dispatchers.IO) {
-        try {
-            val response = service.getIssues(
-                state = state,
-                page = page
-            )
-            val body = response.body()
-            if (response.isSuccessful && body != null)
-                Result.success(body)
-            else
-                Result.failure(Exception("Get User Issues Error"))
-        } catch (e: Exception) {
-            Result.failure(e)
-        }
+    ): Result<List<Issue>> {
+        return dataSource.getUserIssues(state, page)
     }
 
     override suspend fun searchRepos(
         searchText: String,
         page: Int
-    ): Result<RepoResponse> = withContext(Dispatchers.IO) {
-        try {
-            val response = service.searchRepositories(
-                searchText = searchText,
-                page = page
-            )
-            val body = response.body()
-            if (response.isSuccessful && body != null)
-                Result.success(body)
-            else Result.failure(Exception("Search Repos Error"))
-        } catch (e: Exception) {
-            Result.failure(e)
-        }
-    }
-
-    private suspend fun getNotificationInfo(fullUrl: String, id: String): NotificationInfo? {
-        return try {
-            service.getNotificationInfo(fullUrl).body().apply {
-                this?.notificationId = id
-            }
-        } catch (e: Exception) {
-            Log.d("getNotiInfoError", e.cause.toString())
-            null
-        }
-    }
-
-    private suspend fun getStarredRepos(): Int {
-        val response = service.getStarredRepos()
-        val body = response.body()
-        return if (response.isSuccessful && body != null) {
-            body.size
-        } else 0
+    ): Result<RepoResponse> {
+        return dataSource.getRepos(searchText, page)
     }
 
     companion object {

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/model/NotificationInfo.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/model/NotificationInfo.kt
@@ -4,6 +4,5 @@ import com.google.gson.annotations.SerializedName
 
 data class NotificationInfo(
     @SerializedName("number") val number : Int,
-    @SerializedName("comments") val comments : Int,
-    var notificationId : String = ""
+    @SerializedName("comments") val comments : Int
 )

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/ui/notification/NotificationFragment.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/ui/notification/NotificationFragment.kt
@@ -16,6 +16,7 @@ import com.example.woowagithubrepositoryapp.ui.MainViewModel
 import com.example.woowagithubrepositoryapp.ui.adapter.NotificationAdapter
 import com.example.woowagithubrepositoryapp.ui.common.DataLoading
 import com.example.woowagithubrepositoryapp.ui.common.ViewModelFactory
+import kotlinx.coroutines.*
 
 class NotificationFragment : Fragment() {
 
@@ -46,6 +47,11 @@ class NotificationFragment : Fragment() {
         setObserver()
     }
 
+    override fun onStop() {
+        viewModel.refreshNotifications()
+        super.onStop()
+    }
+
     override fun onDestroyView() {
         _binding = null
         super.onDestroyView()
@@ -54,8 +60,8 @@ class NotificationFragment : Fragment() {
     private fun initRecyclerView() {
         binding?.let {
             it.notificationRecyclerView.apply {
-                ItemTouchHelper(NotificationItemHelper(requireContext()) { notification,position ->
-                    markNotification(notification,position)
+                ItemTouchHelper(NotificationItemHelper(requireContext()) { notification ->
+                    markNotification(notification)
                 }).attachToRecyclerView(this)
 
                 this.addOnScrollListener(object : RecyclerView.OnScrollListener(){
@@ -82,19 +88,13 @@ class NotificationFragment : Fragment() {
         }
     }
 
-    private fun redrawNotificationAdapterItemAtPosition(position : Int){
-        notificationAdapter.notifyItemChanged(position)
-    }
-
     private fun initNotifications() {
         if(viewModel.notifications.value?.size == 0)
             viewModel.getNotifications()
     }
 
-    private fun markNotification(notification: Notification,position: Int) {
-        viewModel.markNotificationAsRead(notification = notification) {
-            redrawNotificationAdapterItemAtPosition(position)
-        }
+    private fun markNotification(notification: Notification) {
+        viewModel.removeNotification(notification = notification)
     }
 
     private fun setObserver(){

--- a/app/src/main/java/com/example/woowagithubrepositoryapp/ui/notification/NotificationItemHelper.kt
+++ b/app/src/main/java/com/example/woowagithubrepositoryapp/ui/notification/NotificationItemHelper.kt
@@ -13,7 +13,7 @@ import com.example.woowagithubrepositoryapp.ui.adapter.NotificationAdapter
 import kotlin.math.roundToInt
 
 class NotificationItemHelper(val context: Context,
-                             val mark : (notification : Notification,position : Int) -> Unit,
+                             val mark : (notification : Notification) -> Unit,
 ) : ItemTouchHelper.Callback() {
 
     override fun getMovementFlags(
@@ -34,7 +34,7 @@ class NotificationItemHelper(val context: Context,
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
         val notificationViewHolder = viewHolder as NotificationAdapter.NotificationViewHolder
         notificationViewHolder.binding.notification?.let {
-            mark(it,notificationViewHolder.adapterPosition)
+            mark(it)
         }
     }
 


### PR DESCRIPTION
참고사항
아래 데이터소스를 추가했던 아키텍처 리팩토링한 브랜치를 기반으로 작업하였습니다.

수정 필요한 사항
읽음 처리 후 읽음 목록에 추가된 후에 만약 그대로 앱을 종료해버리면 읽음 처리가 안되기 때문에 이 부분을 수정해야할 것 같습니다.
앱 종료 후에도 추가적인 네트워크 처리 작업이 필요하기 때문에 서비스를 이용해서 처리하는 건 어떨까 싶은데
아무래도 포그라운드 서비스를 사용해야 서비스도 종료가 안되기 때문에 포그라운드 서비스로 나머지 작업을 처리하는 방향으로 
이 문제를 해결하는 건 어떨까 싶습니다.